### PR TITLE
add option HO_DISSIPATION_FACTOR; closes #5

### DIFF
--- a/examples/compute_error_alfven_periodic_2D.m
+++ b/examples/compute_error_alfven_periodic_2D.m
@@ -67,10 +67,11 @@ I_IEq('form_ujbi') = 'USE_UJBI_CENTRAL'; % SPLIT, CENTRAL, PRODUCT
 %Enable or disable Hall-Term
 I_IEq('hall_term') = 'NONE'; % NONE, USE_HALL
 %Enable or disable artificial dissipation
-I_IEq('dissipation') = 'NONE'; %NONE, USE_ARTIFICIAL_DISSIPATION
+I_IEq('dissipation') = 'NONE'; % NONE, USE_ARTIFICIAL_DISSIPATION
 %Specify what kind of artifical dissipation shall be used
-%USE_ADAPTIVE_DISSIPATION, USE_FIRST_ORDER_DISSIPATION, USE_HIGH_ORDER_DISSIPATION
-I_IEq('dissipation_form') = 'USE_ADAPTIVE_DISSIPATION'; 
+    %USE_ADAPTIVE_DISSIPATION, USE_FIRST_ORDER_DISSIPATION, USE_HIGH_ORDER_DISSIPATION
+I_IEq('dissipation_form') = 'USE_HIGH_ORDER_DISSIPATION';
+I_IEq('HO_DISSIPATION_FACTOR') = 1; % a constant (non-negative) factor adapting the influence of the high order dissipation
 %Additional parameters needed for adaptive dissipation. For typical values
 %see Svärd et al. (2009).
 I_IEq('MP2MIN') = 1;
@@ -123,10 +124,10 @@ I_RunOps('periodic') = 'USE_PERIODIC'; % 'NONE', 'USE_PERIODIC'; must be set to 
 % 'x', 'y', 'z'
 % If you want to plot multiple cross sections use
 % 'xy', 'xz', 'yz', 'xyz'
-I_RunOps('plot_numerical_solution') = 0;
-I_RunOps('plot_analytical_solution') = 0;
-I_RunOps('plot_difference') = 0;
-I_RunOps('plot_divergence') = 0;
+I_RunOps('plot_numerical_solution') = '';
+I_RunOps('plot_analytical_solution') = '';
+I_RunOps('plot_difference') = '';
+I_RunOps('plot_divergence') = '';
 %If set to 1 the magnetic field will be saved to I_Results('field_b')
 I_RunOps('save_fields') = false;
 

--- a/examples/compute_error_hall_periodic.m
+++ b/examples/compute_error_hall_periodic.m
@@ -68,7 +68,9 @@ I_IEq('hall_term') = 'USE_HALL'; % NONE, USE_HALL
 %Enable or disable artificial dissipation
 I_IEq('dissipation') = 'NONE'; % NONE, USE_ARTIFICIAL_DISSIPATION
 %Specify what kind of artifical dissipation shall be used
-I_IEq('dissipation_form') = 'USE_HIGH_ORDER_DISSIPATION'; %USE_ADAPTIVE_DISSIPATION USE_FIRST_ORDER_DISSIPATION USE_HIGH_ORDER_DISSIPATION
+    %USE_ADAPTIVE_DISSIPATION, USE_FIRST_ORDER_DISSIPATION, USE_HIGH_ORDER_DISSIPATION
+I_IEq('dissipation_form') = 'USE_HIGH_ORDER_DISSIPATION';
+I_IEq('HO_DISSIPATION_FACTOR') = 1; % a constant (non-negative) factor adapting the influence of the high order dissipation
 %Additional parameters needed for adaptive dissipation. For typical values
 %see (add reference)
 I_IEq('MP2MIN') = 1;
@@ -121,10 +123,10 @@ I_RunOps('periodic') = 'USE_PERIODIC'; % 'NONE', 'USE_PERIODIC'; must be set to 
 % 'x', 'y', 'z'
 % If you want to plot multiple cross sections use
 % 'xy', 'xz', 'yz', 'xyz'
-I_RunOps('plot_numerical_solution') = 0;
-I_RunOps('plot_analytical_solution') = 0;
-I_RunOps('plot_difference') = 0;
-I_RunOps('plot_divergence') = 0;
+I_RunOps('plot_numerical_solution') = '';
+I_RunOps('plot_analytical_solution') = '';
+I_RunOps('plot_difference') = '';
+I_RunOps('plot_divergence') = '';
 %If set to 1 the magnetic field will be saved to I_Results('field_b')
 I_RunOps('save_fields') = false;
 

--- a/examples/compute_error_rotation_2D.m
+++ b/examples/compute_error_rotation_2D.m
@@ -67,10 +67,11 @@ I_IEq('form_ujbi') = 'USE_UJBI_CENTRAL'; % SPLIT, CENTRAL, PRODUCT
 %Enable or disable Hall-Term
 I_IEq('hall_term') = 'NONE'; % NONE, USE_HALL
 %Enable or disable artificial dissipation
-I_IEq('dissipation') = 'NONE'; %NONE, USE_ARTIFICIAL_DISSIPATION
+I_IEq('dissipation') = 'NONE'; % NONE, USE_ARTIFICIAL_DISSIPATION
 %Specify what kind of artifical dissipation shall be used
-%USE_ADAPTIVE_DISSIPATION, USE_FIRST_ORDER_DISSIPATION, USE_HIGH_ORDER_DISSIPATION
-I_IEq('dissipation_form') = 'USE_ADAPTIVE_DISSIPATION'; 
+    %USE_ADAPTIVE_DISSIPATION, USE_FIRST_ORDER_DISSIPATION, USE_HIGH_ORDER_DISSIPATION
+I_IEq('dissipation_form') = 'USE_HIGH_ORDER_DISSIPATION';
+I_IEq('HO_DISSIPATION_FACTOR') = 1; % a constant (non-negative) factor adapting the influence of the high order dissipation
 %Additional parameters needed for adaptive dissipation. For typical values
 %see Svärd et al. (2009).
 I_IEq('MP2MIN') = 1;
@@ -123,10 +124,10 @@ I_RunOps('periodic') = 'NONE'; % 'NONE', 'USE_PERIODIC'; must be set to 'USE_PER
 % 'x', 'y', 'z'
 % If you want to plot multiple cross sections use
 % 'xy', 'xz', 'yz', 'xyz'
-I_RunOps('plot_numerical_solution') = 'xyz';
-I_RunOps('plot_analytical_solution') = 'xyz';
-I_RunOps('plot_difference') = 'xyz';
-I_RunOps('plot_divergence') = 'xyz';
+I_RunOps('plot_numerical_solution') = '';
+I_RunOps('plot_analytical_solution') = '';
+I_RunOps('plot_difference') = '';
+I_RunOps('plot_divergence') = '';
 %If set to 1 the magnetic field will be saved to I_Results('field_b')
 I_RunOps('save_fields') = false;
 

--- a/examples/compute_hall_travelling_wave.m
+++ b/examples/compute_hall_travelling_wave.m
@@ -68,7 +68,9 @@ I_IEq('hall_term') = 'USE_HALL'; % NONE, USE_HALL
 %Enable or disable artificial dissipation
 I_IEq('dissipation') = 'NONE'; % NONE, USE_ARTIFICIAL_DISSIPATION
 %Specify what kind of artifical dissipation shall be used
-I_IEq('dissipation_form') = 'USE_HIGH_ORDER_DISSIPATION'; %USE_ADAPTIVE_DISSIPATION USE_FIRST_ORDER_DISSIPATION USE_HIGH_ORDER_DISSIPATION
+    %USE_ADAPTIVE_DISSIPATION, USE_FIRST_ORDER_DISSIPATION, USE_HIGH_ORDER_DISSIPATION
+I_IEq('dissipation_form') = 'USE_HIGH_ORDER_DISSIPATION';
+I_IEq('HO_DISSIPATION_FACTOR') = 1; % a constant (non-negative) factor adapting the influence of the high order dissipation
 %Additional parameters needed for adaptive dissipation. For typical values
 %see (add reference)
 I_IEq('MP2MIN') = 1;
@@ -121,10 +123,10 @@ I_RunOps('periodic') = 'NONE'; % 'NONE', 'USE_PERIODIC'; must be set to 'USE_PER
 % 'x', 'y', 'z'
 % If you want to plot multiple cross sections use
 % 'xy', 'xz', 'yz', 'xyz'
-I_RunOps('plot_numerical_solution') = 0;
-I_RunOps('plot_analytical_solution') = 0;
-I_RunOps('plot_difference') = 0;
-I_RunOps('plot_divergence') = 0;
+I_RunOps('plot_numerical_solution') = '';
+I_RunOps('plot_analytical_solution') = '';
+I_RunOps('plot_difference') = '';
+I_RunOps('plot_divergence') = '';
 %If set to 1 the magnetic field will be saved to I_Results('field_b')
 I_RunOps('save_fields') = false;
 

--- a/kernel/artificial_dissipation.cl
+++ b/kernel/artificial_dissipation.cl
@@ -4,6 +4,11 @@
 // Artifical Dissipation
 //--------------------------------------------------------------------------------------------------
 
+// a constant (non-negative) factor adapting the influence of the high order dissipation
+#ifndef HO_DISSIPATION_FACTOR
+#define HO_DISSIPATION_FACTOR 1
+#endif
+
 // Computes the high order dissipation for the vector type field `d_field_b` at point (ix, iy, iz)
 inline REAL4 high_order_dissipation(uint ix, uint iy, uint iz, global REAL4 *d_field_b) {
 
@@ -16,9 +21,9 @@ inline REAL4 high_order_dissipation(uint ix, uint iy, uint iz, global REAL4 *d_f
 	REAL4 HO_diss = (REAL4) {0, 0, 0, 0};
 
 	for (int i = -STENCIL_WIDTH_HOD + 1; i < 1; i++) {
-		HO_diss = HO_diss + diff_HOD_x(ix, iy, iz, bound_x, i, d_field_b)
-                      + diff_HOD_y(ix, iy, iz, bound_y, i, d_field_b)
-                      + diff_HOD_z(ix, iy, iz, bound_z, i, d_field_b);
+		HO_diss = HO_diss + (REAL)(HO_DISSIPATION_FACTOR) * diff_HOD_x(ix, iy, iz, bound_x, i, d_field_b)
+                      + (REAL)(HO_DISSIPATION_FACTOR) * diff_HOD_y(ix, iy, iz, bound_y, i, d_field_b)
+                      + (REAL)(HO_DISSIPATION_FACTOR) * diff_HOD_z(ix, iy, iz, bound_z, i, d_field_b);
 	}
 
 	HO_diss.w = 0;
@@ -134,17 +139,17 @@ inline REAL4 adaptive_dissipation(uint ix, uint iy, uint iz, global REAL4 *d_fie
                                  get_vector_field(ix,iy,iz,term + STENCIL_WIDTH_HOD - 2, 0, 0, d_field_b),
                                  get_vector_field(ix,iy,iz,term + STENCIL_WIDTH_HOD - 1, 0, 0, d_field_u),
                                  get_vector_field(ix,iy,iz,term + STENCIL_WIDTH_HOD - 2, 0, 0, d_field_u)).xyz)
-        * diff_HOD_x(ix, iy, iz, bound_x, term, d_field_b).xyz
+        * (REAL)(HO_DISSIPATION_FACTOR) * diff_HOD_x(ix, iy, iz, bound_x, term, d_field_b).xyz
       + (1 - kappa4(1, (REAL)DY, get_vector_field(ix,iy,iz, 0,term + STENCIL_WIDTH_HOD - 1, 0, d_field_b),
                                  get_vector_field(ix,iy,iz, 0,term + STENCIL_WIDTH_HOD - 2, 0, d_field_b),
                                  get_vector_field(ix,iy,iz, 0,term + STENCIL_WIDTH_HOD - 1, 0, d_field_u),
                                  get_vector_field(ix,iy,iz, 0,term + STENCIL_WIDTH_HOD - 2, 0, d_field_u)).xyz)
-        * diff_HOD_y(ix, iy, iz, bound_y, term, d_field_b).xyz
+        * (REAL)(HO_DISSIPATION_FACTOR) * diff_HOD_y(ix, iy, iz, bound_y, term, d_field_b).xyz
       + (1 - kappa4(1, (REAL)DZ, get_vector_field(ix,iy,iz, 0, 0,term + STENCIL_WIDTH_HOD - 1, d_field_b),
                                  get_vector_field(ix,iy,iz, 0, 0,term + STENCIL_WIDTH_HOD - 2, d_field_b),
                                  get_vector_field(ix,iy,iz, 0, 0,term + STENCIL_WIDTH_HOD - 1, d_field_u),
                                  get_vector_field(ix,iy,iz, 0, 0,term + STENCIL_WIDTH_HOD - 2, d_field_u)).xyz)
-        * diff_HOD_z(ix, iy, iz, bound_z, term, d_field_b).xyz;
+        * (REAL)(HO_DISSIPATION_FACTOR) * diff_HOD_z(ix, iy, iz, bound_z, term, d_field_b).xyz;
 	}
 
 	AD_diss.w = 0;

--- a/matlab/+divergence_cleaning/prepare_vars.m
+++ b/matlab/+divergence_cleaning/prepare_vars.m
@@ -26,7 +26,6 @@ function [] = prepare_vars()
     valueSet = {0 0 0 0 0 0 0 0 0 0 0 0};
     I_Mesh = containers.Map(keySet, valueSet);
 
-
     keySet = {'form', 'BNODES', 'absolute_error_threshold', 'g_range', 'l_range','max_iterations'};
     valueSet = {'' 0 0 0 0 0};
     I_DC = containers.Map(keySet, valueSet,'UniformValues',false);

--- a/matlab/+induction_eq/compute_numerical_solution_setup.m
+++ b/matlab/+induction_eq/compute_numerical_solution_setup.m
@@ -88,7 +88,7 @@ end
 if strcmp(I_IEq('dissipation'), 'USE_ARTIFICIAL_DISSIPATION')
     kernel_path_list = [kernel_path_list, {'../include/artificial_dissipation.h'}];
     kernel_path_list = [kernel_path_list, {'../kernel/artificial_dissipation.cl'}];
-    settings_dissipation = generate_settings(I_IEq, {'dissipation', 'dissipation_form'});
+    settings_dissipation = generate_settings(I_IEq, {'dissipation', 'dissipation_form', 'HO_DISSIPATION_FACTOR'});
 
     if strcmp(I_IEq('dissipation_form'),'USE_ADAPTIVE_DISSIPATION')
         settings_dissipation = strcat(settings_dissipation, generate_settings(I_IEq, {'MP2MIN'; 'MP2MAX'; 'CMIN'; 'CMAX'}));

--- a/matlab/+induction_eq/prepare_vars.m
+++ b/matlab/+induction_eq/prepare_vars.m
@@ -34,8 +34,9 @@ function [] = prepare_vars()
     valueSet = {0 0 '' 0 0};
     I_TI = containers.Map(keySet, valueSet,'UniformValues',false);
 
-    keySet = {'form_uibj', 'form_source', 'form_ujbi', 'dissipation', 'dissipation_form', 'hall_term', 'g_range', 'l_range', 'MP2MIN', 'MP2MAX', 'CMIN', 'CMAX'};
-    valueSet = {'' '' '' 0 '' '' 0 0 0 0 0 0};
+    keySet = {'form_uibj', 'form_source', 'form_ujbi', 'dissipation', 'dissipation_form', 'HO_DISSIPATION_FACTOR', ...
+              'hall_term', 'g_range', 'l_range', 'MP2MIN', 'MP2MAX', 'CMIN', 'CMAX'};
+    valueSet = {'' '' '' 'NONE' '' 1 'NONE' 0 0 0 0 0 0};
     I_IEq = containers.Map(keySet, valueSet,'UniformValues',false);
 
     keySet = {'use', 'form', 'BNODES', 'error_threshold', 'g_range', 'l_range','max_iterations'};


### PR DESCRIPTION
See #5. For example, for numerical experiments with low resolution, scaling the high order dissipation by a factor such as `1.e-1` or `1.e-2` can be beneficial.